### PR TITLE
Add a patch to work well with ubuntu 14.04 and ros indigo. Change Graspit! source as github

### DIFF
--- a/graspit/CMakeLists.txt
+++ b/graspit/CMakeLists.txt
@@ -11,7 +11,7 @@ include($ENV{ROS_ROOT}/core/rosbuild/rosbuild.cmake)
 
 rosbuild_init()
 
-execute_process(COMMAND cmake -E chdir ${PROJECT_SOURCE_DIR} make -f Makefile.graspit.svn
+execute_process(COMMAND cmake -E chdir ${PROJECT_SOURCE_DIR} make -f Makefile.graspit.git
                 RESULT_VARIABLE _graspit_make_failed)
 if(_graspit_make_failed)
   message(FATAL_ERROR "Build of graspit failed")

--- a/graspit/Makefile.graspit.git
+++ b/graspit/Makefile.graspit.git
@@ -2,8 +2,8 @@ all: bin/graspit
 
 GIT_DIR = graspit_source
 GIT_URL = https://github.com/mirsking/Graspit.git
-GIT_REVISION=master
-GIT_PATCH = graspit_project.patch graspit_dbase.patch graspit_1404_svn.patch
+GIT_REVISION=zun-devel
+GIT_PATCH = graspit_git.patch
 
 PACKAGE_DIR = $(shell rospack find graspit)
 

--- a/graspit/Makefile.graspit.git
+++ b/graspit/Makefile.graspit.git
@@ -1,0 +1,20 @@
+all: bin/graspit
+
+GIT_DIR = graspit_source
+GIT_URL = https://github.com/mirsking/Graspit.git
+GIT_REVISION=master
+GIT_PATCH = graspit_project.patch graspit_dbase.patch graspit_1404_svn.patch
+
+PACKAGE_DIR = $(shell rospack find graspit)
+
+include $(shell rospack find mk)/git_checkout.mk
+
+bin/graspit: $(GIT_DIR)
+	cd $(GIT_DIR) && qmake "EXT_DESTDIR = $(PACKAGE_DIR)/bin" "ADDITIONAL_INCLUDE_DIR=$(PACKAGE_DIR)/include" "ADDITIONAL_LINK_FLAGS=-Wl,-rpath,$(PACKAGE_DIR)/lib " graspit.pro && make
+
+clean:
+	-rm -rf bin/graspit
+	-cd $(GIT_DIR) && make clean
+
+wipe: clean
+	-rm -rf $(GIT_DIR)

--- a/graspit/Makefile.graspit.svn
+++ b/graspit/Makefile.graspit.svn
@@ -3,7 +3,7 @@ all: bin/graspit
 SVN_DIR = graspit_source
 SVN_URL = svn://svn.code.sf.net/p/graspit/code/trunk
 SVN_REVISION=-r126
-SVN_PATCH = graspit_project.patch graspit_dbase.patch
+SVN_PATCH = graspit_project.patch graspit_dbase.patch graspit_1404_svn.patch
 
 PACKAGE_DIR = $(shell rospack find graspit)
 

--- a/graspit/Makefile.graspit.tarball
+++ b/graspit/Makefile.graspit.tarball
@@ -7,7 +7,7 @@ INITIAL_DIR = build/Graspit
 SOURCE_DIR = graspit_source
 UNPACK_CMD = tar xzf
 MD5SUM_FILE = $(FILENAME).md5sum
-TARBALL_PATCH=graspit_project.patch graspit_dbase.patch
+TARBALL_PATCH=graspit_project.patch graspit_dbase.patch graspit_1404_svn.patch
 
 PACKAGE_DIR = $(shell rospack find graspit)
 

--- a/graspit/graspit/graspit_1404_svn.patch
+++ b/graspit/graspit/graspit_1404_svn.patch
@@ -1,0 +1,1 @@
+Stub put here just so that Make is happy. The one in the package root is actually used.

--- a/graspit/graspit_1404_svn.patch
+++ b/graspit/graspit_1404_svn.patch
@@ -1,0 +1,26 @@
+Index: graspit-lib-LINUX.pro
+===================================================================
+--- graspit-lib-LINUX.pro	(revision 31)
++++ graspit-lib-LINUX.pro	(working copy)
+@@ -21,7 +21,7 @@
+ LIBS	+= -lSoQt -lCoin
+ 
+ #add utility libraries
+-LIBS += -lGL -lpthread
++LIBS += -lGL -lpthread -ldl
+ 
+ MOC_DIR = .moc
+ OBJECTS_DIR = .obj
+Index: src/ivmgr.cpp
+===================================================================
+--- src/ivmgr.cpp	(revision 31)
++++ src/ivmgr.cpp	(working copy)
+@@ -1540,7 +1540,7 @@
+ #endif
+ 
+   int numtypes = myRenderer->getNumWriteFiletypes();
+-  SbList<SbName> extList;
++  SbPList extList;
+   SbString fullname;
+   SbString desc;
+   for (int i=0;i<numtypes;i++) {

--- a/graspit/graspit_git.patch
+++ b/graspit/graspit_git.patch
@@ -1,0 +1,69 @@
+diff --git a/graspit-lib-LINUX.pro b/graspit-lib-LINUX.pro
+index 3ae7f65..120878b 100644
+--- a/graspit-lib-LINUX.pro
++++ b/graspit-lib-LINUX.pro
+@@ -24,7 +24,7 @@ LIBS	+= -lqhull
+ LIBS	+= -lSoQt -lCoin
+ 
+ #add utility libraries
+-LIBS += -lGL -lpthread
++LIBS += -lGL -lpthread -ldl
+ 
+ MOC_DIR = .moc
+ OBJECTS_DIR = .obj
+diff --git a/graspit.pro b/graspit.pro
+index 017fe2f..e0603c5 100644
+--- a/graspit.pro
++++ b/graspit.pro
+@@ -21,9 +21,9 @@ COLLISION = graspit_collision
+ LAPACK = clapack
+ 
+ #build and use interface with Columbia Grasp Database
+-#CONFIG += cgdb
++CONFIG += cgdb
+ #and use the ros database manager
+-#CONFIG += graspit_ros
++CONFIG += graspit_ros
+ 
+ #link against Mosek QP solver (must be installed separately)
+ #CONFIG += mosek
+diff --git a/src/DBase/dbaseDlg.ui b/src/DBase/dbaseDlg.ui
+index 590dc29..3984317 100644
+--- a/src/DBase/dbaseDlg.ui
++++ b/src/DBase/dbaseDlg.ui
+@@ -34,7 +34,7 @@
+      </rect>
+     </property>
+     <property name="text" >
+-     <string>localhost</string>
++     <string>wgs36</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="hostLabel" >
+@@ -99,7 +99,7 @@
+      </rect>
+     </property>
+     <property name="text" >
+-     <string>grasps</string>
++     <string>household_objects</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="usernameLabel" >
+@@ -125,7 +125,7 @@
+      </rect>
+     </property>
+     <property name="text" >
+-     <string></string>
++     <string>willow</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="passwordLabel" >
+@@ -151,7 +151,7 @@
+      </rect>
+     </property>
+     <property name="text" >
+-     <string></string>
++     <string>willow</string>
+     </property>
+     <property name="echoMode" >
+      <enum>QLineEdit::Password</enum>

--- a/graspit_ros_planning/launch/ros_graspit_interface.launch
+++ b/graspit_ros_planning/launch/ros_graspit_interface.launch
@@ -1,5 +1,5 @@
 <launch>
-  <node name="graspit_ros" pkg="graspit" type="graspit" args="plugin:libros_graspit_interface" output="screen">
+  <node name="graspit_ros" pkg="graspit" type="graspit" args="plugin,libros_graspit_interface" output="screen">
     <env name="GRASPIT" value="$(find graspit)/graspit_source"/>
     <env name="GRASPIT_PLUGIN_DIR" value="$(find graspit_ros_planning)/lib"/>
   </node>


### PR DESCRIPTION
Hi, 
I have change Graspit source from sourceforge svn to [github](https://github.com/mirsking/Graspit/tree/master), and the steps I did that is on the readme branch.

And then I add Makefile.graspit.git to the graspit_simulator's graspit_source.
And I also add a patch file graspit_1404_svn.patch(seems it works well with git) so than it can work well with ubuntu 1404 and ros indigo.

Besides, I find Graspit! use ',' as the cmd seperator, so I change the launch file a little.
